### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Kruzk02/grocery-store/security/code-scanning/1](https://github.com/Kruzk02/grocery-store/security/code-scanning/1)

To fix the problem, you should add a `permissions` key to the workflow file, specifying the least privilege required for the workflow to function. Since the workflow only checks out code, sets up .NET, restores dependencies, builds, and runs tests, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This can be set at the workflow level (top-level, after the `name:` key), which will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed; simply add the `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
